### PR TITLE
Always return OK for OPTIONS request

### DIFF
--- a/src/utils/cors.rs
+++ b/src/utils/cors.rs
@@ -1,5 +1,5 @@
 use rocket::fairing::{Fairing, Info, Kind};
-use rocket::http::{ContentType, Header, Method};
+use rocket::http::{ContentType, Header, Method, Status};
 use rocket::{Request, Response};
 use std::io::Cursor;
 
@@ -33,6 +33,7 @@ impl Fairing for CORS {
         if request.method() == Method::Options {
             response.set_header(ContentType::Plain);
             response.set_sized_body(0, Cursor::new(""));
+            response.set_status(Status::Ok);
         }
     }
 }


### PR DESCRIPTION
Without this, preflight requests from Chrome would return 404 which
would cause Chrome to fail the request
